### PR TITLE
Ensure glyph position is non-negative

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -380,7 +380,7 @@ impl Grid {
         let text_x = icon_x + self.icon_size / 2;
         let text_y = icon_y + self.icon_size + TEXT_PADDING;
 
-        GridEntry { icon: (icon_x, icon_y), text: (text_x, text_y) }
+        GridEntry { icon: (icon_x as isize, icon_y as isize), text: (text_x, text_y) }
     }
 
     /// Index of application at the specified location.
@@ -395,7 +395,7 @@ impl Grid {
 #[derive(Debug)]
 struct GridEntry {
     /// Top-left corner for the icon texture.
-    icon: (usize, usize),
+    icon: (isize, isize),
     /// Top-center for the text texture.
     text: (usize, usize),
 }
@@ -412,39 +412,41 @@ impl TextureBuffer {
     }
 
     /// Write an RGBA buffer at the specified location.
-    pub fn write_rgba_at(&mut self, buffer: &[u8], width: usize, pos: (usize, usize)) {
-        for row in 0..buffer.len() / width {
-            let dst_start = (pos.1 + row) * self.width + pos.0 * 4;
-            if dst_start >= self.inner.len() {
-                break;
-            }
-            let dst_row = &mut self.inner[dst_start..];
-
-            let src_start = row * width;
-            let src_row = &buffer[src_start..src_start + cmp::min(width, dst_row.len())];
-
-            let pixels = src_row.chunks(4).enumerate().filter(|(_i, pixel)| pixel != &[0, 0, 0, 0]);
-            for (i, pixel) in pixels {
-                dst_row[i * 4..i * 4 + 4].copy_from_slice(pixel)
-            }
-        }
+    pub fn write_rgba_at(&mut self, buffer: &[u8], width: usize, pos: (isize, isize)) {
+        self.write_buffer_inner::<4>(buffer, width, pos)
     }
 
     /// Write an RGB buffer at the specified location.
-    pub fn write_rgb_at(&mut self, buffer: &[u8], width: usize, pos: (usize, usize)) {
+    pub fn write_rgb_at(&mut self, buffer: &[u8], width: usize, pos: (isize, isize)) {
+        self.write_buffer_inner::<3>(buffer, width, pos);
+    }
+
+    fn write_buffer_inner<const N: usize>(
+        &mut self,
+        buffer: &[u8],
+        width: usize,
+        pos: (isize, isize),
+    ) {
         for row in 0..buffer.len() / width {
-            let dst_start = (pos.1 + row) * self.width + pos.0 * 4;
-            if dst_start >= self.inner.len() {
+            let dst_start = (pos.1 + row as isize) * self.width as isize + pos.0 * 4;
+
+            // Cut the glyphs outside the buffer.
+            if dst_start < 0 {
+                continue;
+            }
+
+            if dst_start >= self.inner.len() as isize {
                 break;
             }
-            let dst_row = &mut self.inner[dst_start..];
+
+            let dst_row = &mut self.inner[dst_start as usize..];
 
             let src_start = row * width;
-            let src_row = &buffer[src_start..src_start + cmp::min(width, dst_row.len() / 4 * 3)];
+            let src_row = &buffer[src_start..src_start + cmp::min(width, dst_row.len() / 4 * N)];
 
-            let pixels = src_row.chunks(3).enumerate().filter(|(_i, pixel)| pixel != &[0, 0, 0]);
+            let pixels = src_row.chunks(N).enumerate().filter(|(_i, pixel)| pixel != &[0; N]);
             for (i, pixel) in pixels {
-                dst_row[i * 4..i * 4 + 3].copy_from_slice(pixel);
+                dst_row[i * 4..i * 4 + N].copy_from_slice(pixel);
             }
         }
     }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -430,15 +430,15 @@ impl TextureBuffer {
         // Clamp dst to zero.
         let dst_x = pos.0.max(0);
 
-        // Compute the amount to cut in the src buffer.
-        let to_cut_x = (dst_x - pos.0).abs() as usize;
-        width -= to_cut_x * N;
+        // Compute pixels to cut off at the beginning of each row.
+        let dst_x_offset = (dst_x - pos.0).abs() as usize;
+        width -= dst_x_offset * N;
 
         for row in 0..buffer.len() / width {
             // Apply `y`.
             let mut dst_start = (pos.1 + row as isize) * self.width as isize;
 
-            // Cut top.
+            // Skip rows outside the destination buffer.
             if dst_start < 0 {
                 continue;
             }
@@ -453,7 +453,7 @@ impl TextureBuffer {
             let dst_row = &mut self.inner[dst_start as usize..];
 
             // Compute the start with-in the buffer.
-            let src_start = row * width + to_cut_x * N;
+            let src_start = row * width + dst_x_offset * N;
             let src_row = &buffer[src_start..src_start + cmp::min(width, dst_row.len() / 4 * N)];
 
             let pixels = src_row.chunks(N).enumerate().filter(|(_i, pixel)| pixel != &[0; N]);

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -435,16 +435,12 @@ impl TextureBuffer {
         width -= dst_x_offset * N;
 
         for row in 0..buffer.len() / width {
-            // Apply `y`.
-            let mut dst_start = (pos.1 + row as isize) * self.width as isize;
+            let dst_start = (pos.1 + row as isize) * self.width as isize + dst_x * N as isize;
 
             // Skip rows outside the destination buffer.
             if dst_start < 0 {
                 continue;
             }
-
-            // Apply `x`.
-            dst_start += dst_x * N as isize;
 
             if dst_start >= self.inner.len() as isize {
                 break;

--- a/src/text.rs
+++ b/src/text.rs
@@ -98,7 +98,7 @@ impl Rasterizer {
 
         let mut glyphs_iter = glyphs.iter().peekable();
         while let Some(glyph) = glyphs_iter.next() {
-            let copy_fun: fn(&mut TextureBuffer, &[u8], usize, (usize, usize));
+            let copy_fun: fn(&mut TextureBuffer, &[u8], usize, (isize, isize));
             let (stride, glyph_buffer) = match &glyph.buffer {
                 BitmapBuffer::Rgb(glyph_buffer) => {
                     copy_fun = TextureBuffer::write_rgb_at;
@@ -112,9 +112,8 @@ impl Rasterizer {
 
             if !glyph_buffer.is_empty() {
                 // Glyph position inside the buffer.
-                let y = usize::try_from((anchor_y + ascent) as i32 - glyph.top).unwrap_or_default();
-                let x = usize::try_from(((anchor_x + offset) as i32 + glyph.left) as isize)
-                    .unwrap_or_default();
+                let y = (anchor_y + ascent) as isize - glyph.top as isize;
+                let x = ((anchor_x + offset) as i32 + glyph.left) as isize;
 
                 // Copy the rasterized glyph to the output buffer.
                 let row_width = glyph.width as usize * stride;

--- a/src/text.rs
+++ b/src/text.rs
@@ -112,8 +112,9 @@ impl Rasterizer {
 
             if !glyph_buffer.is_empty() {
                 // Glyph position inside the buffer.
-                let y = anchor_y + ascent - glyph.top as usize;
-                let x = ((anchor_x + offset) as i32 + glyph.left) as usize;
+                let y = usize::try_from((anchor_y + ascent) as i32 - glyph.top).unwrap_or_default();
+                let x = usize::try_from(((anchor_x + offset) as i32 + glyph.left) as isize)
+                    .unwrap_or_default();
 
                 // Copy the rasterized glyph to the output buffer.
                 let row_width = glyph.width as usize * stride;


### PR DESCRIPTION
This prevents convertion error when manipulating with text glyphs.