### PR TITLE
Convert all PNGs into Rgba8

### DIFF
--- a/src/xdg.rs
+++ b/src/xdg.rs
@@ -259,7 +259,7 @@ impl IconLoader {
 
                 // Premultiply alpha.
                 let width = image.width() as usize;
-                let mut data = image.into_bytes();
+                let mut data = image.into_rgba8().into_raw();
                 for chunk in data.chunks_mut(4) {
                     chunk[0] = (chunk[0] as f32 * chunk[3] as f32 / 255.).round() as u8;
                     chunk[1] = (chunk[1] as f32 * chunk[3] as f32 / 255.).round() as u8;


### PR DESCRIPTION
Fixes icons of melonDS, Kolourpaint, Neverball or Puzzles being garbled due to being stored in a different colour format.

![tzompantli-puzzles-neverball](https://github.com/catacombing/tzompantli/assets/7755816/1523d5e5-6dab-49b9-9c6d-4400ef387a27)