### PR TITLE
Better .desktop parsing and icon selection

### DIFF
--- a/src/svg.rs
+++ b/src/svg.rs
@@ -1,6 +1,6 @@
 //! SVG rasterization.
 
-use std::path::PathBuf;
+use std::path::Path;
 use std::{fs, io};
 
 use tiny_skia::{Pixmap, Transform};
@@ -35,7 +35,7 @@ pub struct Svg {
 
 impl Svg {
     /// Render an SVG from a path at a specific size.
-    pub fn from_path(path: &PathBuf, size: u32) -> Result<Self, Error> {
+    pub fn from_path<P: AsRef<Path>>(path: P, size: u32) -> Result<Self, Error> {
         let file = fs::read(path)?;
         Self::from_buffer(&file, size)
     }

--- a/src/xdg.rs
+++ b/src/xdg.rs
@@ -1,7 +1,7 @@
 //! Enumerate installed applications.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::{fs, io, iter, slice};
 
@@ -253,9 +253,16 @@ impl IconLoader {
 
     /// Load image file as RGBA buffer.
     fn load(&self, icon: &str, size: u32) -> Result<Icon, Error> {
+        let mut path = Path::new(icon);
         let name = icon.into();
 
-        let path = self.icons.get(icon).ok_or(Error::NotFound)?;
+        if path.is_absolute() {
+            if !path.exists() {
+                return Err(Error::NotFound);
+            }
+        } else {
+            path = self.icons.get(icon).ok_or(Error::NotFound)?;
+        }
         let path_str = path.to_string_lossy();
 
         match &path_str[path_str.len() - 4..] {

--- a/src/xdg.rs
+++ b/src/xdg.rs
@@ -17,13 +17,17 @@ const PLACEHOLDER_ICON_NAME: &str = "tzompantli-placeholder";
 
 /// Icon lookup paths in reverse order relative to the `$XDG_DATA_DIR`.
 const ICON_PATHS: &[(&str, &str)] = &[
+    ("icons/hicolor/16x16/apps/", "png"),
+    ("icons/hicolor/24x24/apps/", "png"),
     ("icons/hicolor/32x32/apps/", "png"),
-    ("icons/hicolor/64x64/apps/", "png"),
+    ("icons/hicolor/48x48/apps/", "png"),
+    ("icons/hicolor/512x512/apps/", "png"),
     ("icons/hicolor/256x256/apps/", "png"),
-    ("icons/hicolor/scalable/apps/", "svg"),
     ("icons/hicolor/128x128/apps/", "png"),
-    ("pixmaps/", "svg"),
+    ("icons/hicolor/64x64/apps/", "png"),
     ("pixmaps/", "png"),
+    ("icons/hicolor/scalable/apps/", "svg"),
+    ("pixmaps/", "svg"),
 ];
 
 /// Desired size for PNG icons at a scale factor of 1.


### PR DESCRIPTION
Parse .desktop files a bit better, ignore any non-`[Desktop Entry]` section and obey `NoDisplay`. Also reorder icon paths and add some more.

What is still missing and can be implemented in the future:
- case insensitive and language-aware sort,
- display localised names,
- handle `-symbolic` icons, required by at least gucharmap.