### PR TITLE
Split SVG rendering in two steps

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -176,13 +176,13 @@ impl Renderer {
         // Write power button to texture.
         let poweroff_spot = self.grid.spot(0);
         let svg = &self.power_menu.poweroff;
-        buffer.write_rgba_at(&svg.data, svg.width * 4, poweroff_spot.icon);
+        buffer.write_rgba_at(svg.data(), svg.width() * 4, poweroff_spot.icon);
         let _ = self.rasterizer.rasterize(&mut buffer, poweroff_spot.text, "Poweroff", max_width);
 
         // Write reboot button to texture.
         let reboot_spot = self.grid.spot(self.grid.columns.saturating_sub(1));
         let svg = &self.power_menu.reboot;
-        buffer.write_rgba_at(&svg.data, svg.width * 4, reboot_spot.icon);
+        buffer.write_rgba_at(svg.data(), svg.width() * 4, reboot_spot.icon);
         let _ = self.rasterizer.rasterize(&mut buffer, reboot_spot.text, "Reboot", max_width);
 
         // Stage texture buffer for rendering.
@@ -333,8 +333,11 @@ impl PowerMenu {
         const POWEROFF_SVG: &[u8] = include_bytes!("../svgs/poweroff.svg");
         const REBOOT_SVG: &[u8] = include_bytes!("../svgs/reboot.svg");
 
-        let poweroff = Svg::from_buffer(POWEROFF_SVG, size)?;
-        let reboot = Svg::from_buffer(REBOOT_SVG, size)?;
+        let mut poweroff = Svg::parse(POWEROFF_SVG)?;
+        let mut reboot = Svg::parse(REBOOT_SVG)?;
+
+        poweroff.render(size)?;
+        reboot.render(size)?;
 
         Ok(Self { poweroff, reboot, size })
     }
@@ -347,9 +350,9 @@ impl PowerMenu {
         }
 
         // Attempt to re-rasterize at new size.
-        if let Ok(power_menu) = Self::new(size) {
-            *self = power_menu;
-        }
+        self.poweroff.render(size).expect("Poweroff icon failed to resize");
+        self.reboot.render(size).expect("Reboot icon failed to resize");
+        self.size = size;
     }
 }
 

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -1,5 +1,6 @@
 //! SVG rasterization.
 
+use core::fmt;
 use std::path::Path;
 use std::{fs, io};
 
@@ -26,34 +27,58 @@ impl From<io::Error> for Error {
     }
 }
 
-/// Rendered SVG.
-#[derive(Debug)]
+/// Parsed SVG, possibly rendered.
 pub struct Svg {
-    pub data: Vec<u8>,
-    pub width: usize,
+    tree: resvg::Tree,
+    data: Vec<u8>,
+    size: u32,
+}
+
+impl fmt::Debug for Svg {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Svg").finish()
+    }
 }
 
 impl Svg {
-    /// Render an SVG from a path at a specific size.
-    pub fn from_path<P: AsRef<Path>>(path: P, size: u32) -> Result<Self, Error> {
+    /// Parse a SVG from a path, but don’t render it yet.
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
         let file = fs::read(path)?;
-        Self::from_buffer(&file, size)
+        Self::parse(&file)
     }
 
-    /// Render an SVG from XML byte buffer at a specific size.
-    pub fn from_buffer(buffer: &[u8], size: u32) -> Result<Self, Error> {
+    /// Parse a SVG from an XML byte buffer, but don’t render it yet.
+    pub fn parse(buffer: &[u8]) -> Result<Self, Error> {
         let options = Options::default();
         let tree = Tree::from_data(buffer, &options)?;
-        let scale = (size as f32 / tree.size.width()).min(size as f32 / tree.size.height());
-
-        let mut pixmap = Pixmap::new(size, size).ok_or(Error::InvalidSize)?;
         let tree = resvg::Tree::from_usvg(&tree);
-        let transform = Transform::from_scale(scale, scale);
-        tree.render(transform, &mut pixmap.as_mut());
+        let data = Vec::new();
+        let size = 0;
+        Ok(Svg { tree, data, size })
+    }
 
-        let width = pixmap.width() as usize;
-        let data = pixmap.take();
+    /// Render this SVG at a specific size.
+    pub fn render(&mut self, size: u32) -> Result<(&[u8], u32), Error> {
+        if self.size != size {
+            let tree_size = self.tree.size;
+            let scale = (size as f32 / tree_size.width()).min(size as f32 / tree_size.height());
+            let transform = Transform::from_scale(scale, scale);
 
-        Ok(Self { data, width })
+            let mut pixmap = Pixmap::new(size, size).ok_or(Error::InvalidSize)?;
+            self.tree.render(transform, &mut pixmap.as_mut());
+
+            self.size = pixmap.width();
+            self.data = pixmap.take();
+        }
+
+        Ok((&self.data, self.size))
+    }
+
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    pub fn width(&self) -> usize {
+        self.size as usize
     }
 }

--- a/src/xdg.rs
+++ b/src/xdg.rs
@@ -212,12 +212,9 @@ impl Icon {
     /// Create new "missing icon" icon.
     fn new_placeholder(size: u32) -> Result<Self, Error> {
         const PLACEHOLDER_SVG: &[u8] = include_bytes!("../svgs/placeholder.svg");
-        let placeholder = Svg::from_buffer(PLACEHOLDER_SVG, size)?;
-        Ok(Icon {
-            data: placeholder.data,
-            width: placeholder.width,
-            name: PLACEHOLDER_ICON_NAME.into(),
-        })
+        let mut placeholder = Svg::parse(PLACEHOLDER_SVG)?;
+        let (data, width) = placeholder.render(size)?;
+        Ok(Icon { data: data.to_vec(), width: width as usize, name: PLACEHOLDER_ICON_NAME.into() })
     }
 }
 
@@ -356,8 +353,9 @@ impl IconLoader {
                 Ok(Icon { data, width, name })
             },
             Some("svg") => {
-                let svg = Svg::from_path(path, size)?;
-                Ok(Icon { data: svg.data, width: svg.width, name })
+                let mut svg = Svg::from_path(path)?;
+                let (data, width) = svg.render(size)?;
+                Ok(Icon { data: data.to_vec(), width: width as usize, name })
             },
             _ => unreachable!(),
         }


### PR DESCRIPTION
resvg has the interesting property that it does half of the work during Tree building, to then make rendering as fast as possible.

For now we only use this to avoid re-parsing the poweroff and reboot icons, but in the future we can use this also on other icons.

In the future we will also do the parsing early in a thread pool, and only do the rendering once we know the size at which we will get displayed.