### PR TITLE
Better icon theme handling

### DIFF
--- a/src/xdg.rs
+++ b/src/xdg.rs
@@ -2,7 +2,7 @@
 
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use core::arch::aarch64::*;
-use core::cmp::Ordering;
+use core::cmp::{self, Ordering};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
@@ -221,10 +221,40 @@ enum ImageType {
     Symbolic,
 }
 
+impl Ord for ImageType {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if self == other {
+            return Ordering::Equal;
+        }
+
+        match (self, other) {
+            // Prefer scaleable formats.
+            (Self::Scalable, _) => Ordering::Greater,
+            (_, Self::Scalable) => Ordering::Less,
+            // Prefer bigger bitmap sizes.
+            (Self::SizedBitmap(size), Self::SizedBitmap(other_size)) => size.cmp(other_size),
+            // Prefer bitmaps with known size.
+            (Self::SizedBitmap(_), _) => Ordering::Greater,
+            (_, Self::SizedBitmap(_)) => Ordering::Less,
+            // Prefer bitmaps over symbolic icons without color.
+            (Self::Bitmap, _) => Ordering::Greater,
+            (_, Self::Bitmap) => Ordering::Less,
+            // Equality is checked by the gate clause already.
+            (Self::Symbolic, Self::Symbolic) => unreachable!(),
+        }
+    }
+}
+
+impl PartialOrd for ImageType {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 /// Simple loader for app icons.
 #[derive(Debug)]
 struct IconLoader {
-    icons: HashMap<String, Vec<(ImageType, PathBuf)>>,
+    icons: HashMap<String, HashMap<ImageType, PathBuf>>,
 }
 
 impl IconLoader {
@@ -315,38 +345,37 @@ impl IconLoader {
             icons.entry(name.to_owned()).or_default().insert(image_type, file.path());
         }
 
-        // We want the icons mostly sorted by preferred size, so that further sorts
-        // which happen during resize don’t take too much time.
-        let icons = icons
-            .into_iter()
-            .map(|(name, icons)| {
-                let mut icons: Vec<_> = icons.into_iter().collect();
-                Self::sort_by_icon_types(&mut icons, ICON_SIZE);
-                (name, icons)
-            })
-            .collect();
-
         Self { icons }
     }
 
-    fn sort_by_icon_types(icons: &mut [(ImageType, PathBuf)], size: u32) {
-        // Sort icons by best match for the desired size.
-        icons.sort_by_key(|(icon_type, _)| match icon_type {
-            ImageType::SizedBitmap(icon_size) => match icon_size.cmp(&size) {
-                // If the size of the PNG is identical to ours, it’s the best option.
-                Ordering::Equal => 0,
-                // Otherwise order by closest size bigger than ours.
-                Ordering::Greater => icon_size - size,
-                // And only prefer smaller sizes after unknown sizes.
-                Ordering::Less => 8192 + size - icon_size,
+    /// Get the ideal icon for a specific size.
+    fn icon_path<'a>(&'a self, icon: &str, size: u32) -> Result<&'a Path, Error> {
+        // Get all available icons matching this icon name.
+        let icons = self.icons.get(icon).ok_or(Error::NotFound)?;
+        let mut icons = icons.iter();
+
+        // Initialize accumulator with the first iterator item.
+        let mut ideal_icon = match icons.next() {
+            // Short-circuit if the first icon is an exact match.
+            Some((ImageType::SizedBitmap(icon_size), path)) if *icon_size == size => {
+                return Ok(path.as_path())
             },
-            // Scalable is obviously the second best option to get crisp icons.
-            ImageType::Scalable => 1,
-            // Here we take the bet that an unknown file will be better than a known smaller.
-            ImageType::Bitmap => 8192,
-            // And finally, symbolic is the same icon but without colours, usually too dark.
-            ImageType::Symbolic => 16384,
-        });
+            Some(first_icon) => first_icon,
+            None => return Err(Error::NotFound),
+        };
+
+        // Find the ideal icon.
+        for icon in icons {
+            // Short-circuit if an exact size match exists.
+            if matches!(icon, (ImageType::SizedBitmap(icon_size), _) if *icon_size == size) {
+                return Ok(icon.1);
+            }
+
+            // Otherwise find closest match.
+            ideal_icon = cmp::max(icon, ideal_icon);
+        }
+
+        Ok(ideal_icon.1.as_path())
     }
 
     fn premultiply_generic(data: &mut [u8]) {
@@ -417,14 +446,7 @@ impl IconLoader {
         // Resolve icon from name if it is not an absolute path.
         let mut path = Path::new(icon);
         if !path.is_absolute() {
-            // Get all available icons matching this icon name.
-            let matching_icons = self.icons.get_mut(icon).ok_or(Error::NotFound)?;
-
-            // Sort icons by best match for the desired size.
-            Self::sort_by_icon_types(matching_icons, size);
-
-            // Return the optimal match.
-            path = &matching_icons[0].1;
+            path = self.icon_path(icon, size)?;
         }
 
         match path.extension().and_then(|ext| ext.to_str()) {


### PR DESCRIPTION
We previously were going through a list of hardcoded paths, but this was causing issues such as no handling for different themes (not supported in this commit), or different preferences in directories when the scale factor changes for instance.