### PR TITLE
Treat .svgz as .svg for icon loading

### DIFF
--- a/src/xdg.rs
+++ b/src/xdg.rs
@@ -469,7 +469,7 @@ impl IconLoader {
 
                 Ok(Icon { data, width, name })
             },
-            Some("svg") => {
+            Some("svg") | Some("svgz") => {
                 let mut svg = Svg::from_path(path)?;
                 let (data, width) = svg.render(size)?;
                 Ok(Icon { data: data.to_vec(), width: width as usize, name })


### PR DESCRIPTION
Fixes Kolourpaint’s icon when rendered at scale=1 (it only ships icons of size 16..48 and 128, not 64).  Thankfully, resvg handles gzip compression transparently.

```
thread 'main' panicked at 'internal error: entered unreachable code', src/xdg.rs:477:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```