### PR TITLE
Exit when the Escape key is pressed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ resvg = { version = "0.35", default-features = false }
 xdg = "2.4.1"
 zbus = { version = "3.11.0", default-features = false, features = ["tokio"] }
 tokio = "1.26.0"
+xkbcommon = { version = "0.5.1", default-features = false }
 
 [build-dependencies]
 gl_generator = "0.14.0"


### PR DESCRIPTION
When the user has a keyboard plugged in, pressing the Escape key will now exit tzompantli.  This is useful when developing on a computer with a keyboard attached, including the PinePhone keyboard.